### PR TITLE
Fix Non Ranked Games

### DIFF
--- a/app/controllers/recentgames.go
+++ b/app/controllers/recentgames.go
@@ -7,47 +7,32 @@ import (
 	model "github.com/telrikk/ask-zilean/app/recentgames"
 	"github.com/telrikk/ask-zilean/app/util"
 	"github.com/telrikk/lol-go-api/game"
-	"github.com/telrikk/lol-go-api/match"
 )
 
-var queueDescriptions = map[string]string{
-	"ARAM_5x5":                        "(ARAM)",
-	"BILGEWATER_5x5":                  "(Bilgewater)",
-	"BILGEWATER_ARAM_5x5":             "(ARAM)",
-	"ASCENSION_5x5":                   "(Ascension)",
-	"NORMAL_5x5_BLIND":                "(Blind)",
-	"BOT_5x5":                         "(Bots)",
-	"BOT_5x5_BEGINNER":                "(Bots)",
-	"BOT_5x5_INTERMEDIATE":            "(Bots)",
-	"BOT_5x5_INTRO":                   "(Bots)",
-	"BOT_TT_3x3":                      "(Bots)",
-	"BOT_ODIN_5x5":                    "(Bots)",
-	"BOT_URF_5x5":                     "(Bots)",
-	"COUNTER_PICK":                    "(Counter Pick)",
-	"CUSTOM":                          "(Custom)",
-	"NORMAL_5x5_DRAFT":                "(Draft)",
-	"FIRSTBLOOD_1x1":                  "(First Blood)",
-	"FIRSTBLOOD_2x2":                  "(First Blood)",
-	"HEXAKILL":                        "(Hexakill)",
-	"KING_PORO_5x5":                   "(King Poro)",
-	"SR_6x6":                          "(Hexakill)",
-	"NIGHTMARE_BOT_5x5_RANK1":         "(Bots)",
-	"NIGHTMARE_BOT_5x5_RANK5":         "(Bots)",
-	"NIGHTMARE_BOT_5x5_RANK2":         "(Bots)",
-	"ODIN_5x5_BLIND":                  "(Dominion)",
-	"ODIN_5x5_DRAFT":                  "(Odin)",
-	"ONEFORALL_MIRRORMODE_5x5":        "(One For All)",
-	"ONEFORALL_5x5":                   "(One For All)",
-	"RANKED_PREMADE_3x3":              "(Team Ranked)",
-	"RANKED_PREMADE_5x5":              "(Team Ranked)",
-	"RANKED_SOLO_5x5":                 "(Ranked)",
-	"RANKED_TEAM_5x5":                 "(Team Ranked)",
-	"RANKED_TEAM_3x3":                 "(Team Ranked)",
-	"NORMAL_3x3":                      "(Normal)",
-	"GROUP_FINDER_5x5":                "(Team Builder)",
-	"TEAM_BUILDER_DRAFT_UNRANKED_5x5": "(Normal)",
-	"TEAM_BUILDER_DRAFT_RANKED_5x5":   "(Ranked)",
-	"URF_5x5":                         "(URF)",
+var gameSubTypeMap = map[string]string{
+	"BOT":                "(Bots)",
+	"NORMAL":             "(Normal)",
+	"ODIN_UNRANKED":      "(Dominion)",
+	"RANKED_PREMADE_3x3": "(Team Ranked)",
+	"RANKED_PREMADE_5x5": "(Team Ranked)",
+	"NORMAL_3x3":         "(Twisted Treeline)",
+	"BOT_3x3":            "(Bots)",
+	"ARAM_UNRANKED_5x5":  "(ARAM)",
+	"URF":                "(URF)",
+	"URF_BOT":            "(Bots)",
+	"ASCENSION":          "(Ascension)",
+	"NIGHTMARE_BOT":      "(Bots)",
+	"COUNTER_PICK":       "(Counter Pick)",
+	"KING_PORO":          "(King Poro)",
+	"BILGEWATER":         "(Bilgewater)",
+	"HEXAKILL":           "(Hexakill)",
+	"SR_6x6":             "(Hexakill)",
+	"FIRSTBLOOD_1x1":     "(First Blood)",
+	"FIRSTBLOOD_2x2":     "(First Blood)",
+	"ONEFORALL_5x5":      "(One For All)",
+	"RANKED_SOLO_5x5":    "(Ranked)",
+	"RANKED_TEAM_5x5":    "(Team Ranked)",
+	"RANKED_TEAM_3x3":    "(Team Ranked)",
 }
 
 var mapNames = map[string]string{
@@ -68,13 +53,9 @@ func (c App) RecentGames(name string) revel.Result {
 	if err != nil {
 		return util.HandleError(*c.Controller, err)
 	}
-	fullGameData, err := model.GetFullGameData(recentGames)
-	if err != nil {
-		return util.HandleError(*c.Controller, err)
-	}
 	var games []model.RecentGame
 	for _, recentGame := range recentGames {
-		translatedGame := translateRecentGame(recentGame, fullGameData, summonerID, name)
+		translatedGame := translateRecentGame(recentGame, summonerID, name)
 		if translatedGame.ID != 0 {
 			games = append(games, translatedGame)
 		}
@@ -84,18 +65,8 @@ func (c App) RecentGames(name string) revel.Result {
 	return c.RenderJson(response)
 }
 
-func translateRecentGame(game game.Game, gameData map[int]match.Detail, summonerID int, summonerName string) model.RecentGame {
+func translateRecentGame(game game.Game, summonerID int, summonerName string) model.RecentGame {
 	translatedGame := new(model.RecentGame)
-	fullGame := gameData[game.GameID]
-	nameData := make(map[int]string)
-	for _, participant := range fullGame.ParticipantIdentities {
-		// HACK: bad data on Riot's side, will need to use summoner API for non-ranked games
-		nameData[participant.ParticipantID] = participant.Player.SummonerName
-	}
-	for _, player := range fullGame.Participants {
-		translatedPlayer := translatePlayer(player, nameData)
-		translatedGame.Players = append(translatedGame.Players, translatedPlayer)
-	}
 	translatedGame.Summoner = translateSummoner(game, summonerName)
 	mapImageName := util.MapData().Data[strconv.Itoa(game.MapID)].Image.Full
 	translatedGame.MapImageURL = util.MapImagePrefix() + "map/" + mapImageName
@@ -111,7 +82,7 @@ func translateRecentGame(game game.Game, gameData map[int]match.Detail, summoner
 		readableMapName = "Unknown Map"
 	}
 	translatedGame.MapName = readableMapName
-	description, ok := queueDescriptions[fullGame.QueueType]
+	description, ok := gameSubTypeMap[game.SubType]
 	if !ok {
 		description = "(Other)"
 	}
@@ -141,28 +112,6 @@ func translateSummoner(game game.Game, summonerName string) model.Player {
 	translatedPlayer.IsWinner = game.Stats.Win
 	return *translatedPlayer
 
-}
-
-func translatePlayer(player match.Participant, nameData map[int]string) model.Player {
-	translatedPlayer := new(model.Player)
-	translatedPlayer.SummonerName = nameData[player.ParticipantID]
-	translatedPlayer.Kills = player.Stats.Kills
-	translatedPlayer.Assists = player.Stats.Assists
-	translatedPlayer.Deaths = player.Stats.Deaths
-	championImageName := util.ChampionData().Data[strconv.Itoa(player.ChampionID)].Image.Full
-	translatedPlayer.ChampionImageURL = util.ChampionImagePrefix() + "champion/" + championImageName
-	translatedPlayer.ChampionName = util.ChampionData().Data[strconv.Itoa(player.ChampionID)].Name
-	translatedPlayer.Items = []model.Item{}
-	for _, ItemID := range []int{player.Stats.Item0, player.Stats.Item1, player.Stats.Item2,
-		player.Stats.Item3, player.Stats.Item4, player.Stats.Item5, player.Stats.Item6} {
-		if ItemID > 0 {
-			translatedPlayer.Items = append(translatedPlayer.Items, translateItem(ItemID))
-		}
-	}
-	translatedPlayer.CreepScore = player.Stats.MinionsKilled + player.Stats.NeutralMinionsKilled
-	translatedPlayer.Gold = player.Stats.GoldEarned
-	translatedPlayer.IsWinner = player.Stats.Winner
-	return *translatedPlayer
 }
 
 func translateItem(itemID int) model.Item {

--- a/app/recentgames/recentgames.go
+++ b/app/recentgames/recentgames.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/telrikk/ask-zilean/app/util"
 	"github.com/telrikk/lol-go-api/game"
-	"github.com/telrikk/lol-go-api/match"
 )
 
 // Item is an item which was purchased in a recent game
@@ -30,17 +29,16 @@ type Player struct {
 
 // RecentGame is a recently played game
 type RecentGame struct {
-	MapImageURL        string   `json:"mapImageURL"`
-	MapName            string   `json:"mapName"`
-	QueueDescription   string   `json:"queueDescription"`
-	Players            []Player `json:"players"` // all players in the game
-	ID                 int      `json:"id"`
-	Summoner           Player   `json:"summoner"` // the summoner who is using the app
-	CreepScoreImageURL string   `json:"creepScoreImageURL"`
-	StatsImageURL      string   `json:"statsImageURL"`
-	ItemsImageURL      string   `json:"itemsImageURL"`
-	ChampionImageURL   string   `json:"championImageURL"`
-	GoldImageURL       string   `json:"goldImageURL"`
+	MapImageURL        string `json:"mapImageURL"`
+	MapName            string `json:"mapName"`
+	QueueDescription   string `json:"queueDescription"`
+	ID                 int    `json:"id"`
+	Summoner           Player `json:"summoner"` // the summoner who is using the app
+	CreepScoreImageURL string `json:"creepScoreImageURL"`
+	StatsImageURL      string `json:"statsImageURL"`
+	ItemsImageURL      string `json:"itemsImageURL"`
+	ChampionImageURL   string `json:"championImageURL"`
+	GoldImageURL       string `json:"goldImageURL"`
 }
 
 // Response contains a list of recently played games for a summoner
@@ -58,20 +56,6 @@ func GetSummonerID(summonerName string) (int, error) {
 	}
 	summonerID := summonerData.SummonerData[strings.ToLower(summonerName)].ID
 	return summonerID, nil
-}
-
-// GetFullGameData ,given a list of games, returns a data structure with additional information,
-// keyed on a map by match ID
-func GetFullGameData(games []game.Game) (map[int]match.Detail, error) {
-	gameData := make(map[int]match.Detail)
-	for _, game := range games {
-		fullGame, err := util.GetServiceFactory().MatchService().Get(game.GameID, false)
-		if err != nil {
-			return nil, err
-		}
-		gameData[fullGame.MatchID] = *fullGame
-	}
-	return gameData, nil
 }
 
 // GetRecentGames gets the recent games for a summoner, given their ID

--- a/public/js/recent-game.js
+++ b/public/js/recent-game.js
@@ -16,6 +16,8 @@ export default function RecentGame(props) {
   const gold = props.game.summoner.gold;
   const isWinner = props.game.summoner.isWinner;
   const barClass = isWinner ? 'results-bar-victory' : 'results-bar-defeat';
+  const outcomeTextClass = isWinner ? 'victory-text' : 'defeat-text';
+  const outcomeText = isWinner ? 'VICTORY' : 'DEFEAT';
   return (
     <li className="list-group-item">
       <span className={barClass} />
@@ -29,6 +31,7 @@ export default function RecentGame(props) {
           />
         </span>
         <span className="queue-description">
+          <div className={outcomeTextClass}>{outcomeText}</div>
           <div>{props.game.mapName}</div>
           <div>{props.game.queueDescription}</div>
         </span>

--- a/public/sass/main.sass
+++ b/public/sass/main.sass
@@ -1,5 +1,7 @@
 $font-stack:    Helvetica, sans-serif
 $primary-color: #333
+$victory-color: #6ed56e
+$defeat-color: #a63935
 
 =border-radius($radius)
   -webkit-border-radius: $radius
@@ -141,6 +143,8 @@ body
   min-width: 150px
   text-align: center
   margin-right: 8%
+  padding-top: 25px
+  padding-bottom: 25px
 
 .minions
   width: 32px
@@ -185,6 +189,18 @@ body
   right: 15px
   top: 15px
 
+.outcome-text
+  font-size: 16px
+  font-weight: bold
+
+.victory-text
+  @extend .outcome-text
+  color: $victory-color
+
+.defeat-text
+  @extend .outcome-text
+  color: $defeat-color
+
 .results-bar
   border: rgba(255, 255, 255, 0.2) solid
   width: 10px
@@ -196,8 +212,8 @@ body
 
 .results-bar-victory
   @extend .results-bar
-  background-color: #6ed56e
+  background-color: $victory-color
 
 .results-bar-defeat
   @extend .results-bar
-  background-color: #a63935
+  background-color: $defeat-color


### PR DESCRIPTION
It looks like summoner participant data is only provided for ranked games.
- [x] Normal games should appear in the recent games list.
- [x] Evaluate if fetching entire game is still worthwhile, since the page doesn't actually need that information to render.
- [x] Add victory or defeat text
